### PR TITLE
Add FastAPI demo for content distribution flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,30 @@
 # Rockey-V
-AI Transfer &amp; Distribution of Video Contents
+
+AI Transfer & Distribution of Video Contents
+
+## Demo overview
+A minimal FastAPI backend demonstrating an upload-to-distribution flow using in-memory storage and verbose logging.
+
+### Core data structures
+- **Content**: tracks uploaded video metadata and status transitions to `ready_for_distribution`.
+- **DistributionIntent**: represents a user's choice to distribute content to a platform with initial status `pending`.
+
+### API endpoints
+- `POST /upload`: upload a video file, returns `content_id` and content status.
+- `GET /content/{id}`: fetch content details.
+- `POST /intent`: create a distribution intent for a content ID and target platform.
+- `GET /intent/{id}`: fetch intent details.
+- `GET /health`: simple health check.
+
+### Running the demo
+1. Install dependencies: `pip install -r requirements.txt`
+2. Start the server: `uvicorn main:app --reload`
+3. Example requests (using `httpie`):
+   ```bash
+   http -f POST :8000/upload file@/path/to/video.mp4
+   http POST :8000/intent content_id==<content_id> platform==YouTube
+   http GET :8000/content/<content_id>
+   http GET :8000/intent/<intent_id>
+   ```
+
+All state is stored in memory and resets when the server restarts. Logging prints every status change and retrieval for clarity.

--- a/main.py
+++ b/main.py
@@ -1,0 +1,115 @@
+import logging
+import uuid
+from typing import Dict, Optional
+
+from fastapi import FastAPI, File, HTTPException, UploadFile
+from pydantic import BaseModel, Field
+
+logging.basicConfig(level=logging.INFO, format="[%(asctime)s] %(levelname)s %(message)s")
+logger = logging.getLogger(__name__)
+
+app = FastAPI(title="Content Distribution Demo")
+
+
+class Content(BaseModel):
+    id: str = Field(..., description="Unique content identifier")
+    filename: str = Field(..., description="Uploaded filename")
+    status: str = Field(..., description="Current content status")
+
+
+class ContentResponse(Content):
+    pass
+
+
+class DistributionIntent(BaseModel):
+    id: str = Field(..., description="Unique distribution intent identifier")
+    content_id: str = Field(..., description="Linked content identifier")
+    platform: str = Field(..., description="Target distribution platform")
+    status: str = Field(..., description="Current intent status")
+
+
+class CreateIntentRequest(BaseModel):
+    content_id: str
+    platform: str
+
+
+class IntentResponse(DistributionIntent):
+    pass
+
+
+# In-memory storage
+contents: Dict[str, Content] = {}
+intents: Dict[str, DistributionIntent] = {}
+
+
+@app.post("/upload", response_model=ContentResponse)
+async def upload(file: UploadFile = File(...)) -> ContentResponse:
+    logger.info("Received upload request for file: %s", file.filename)
+    content_id = str(uuid.uuid4())
+
+    content = Content(id=content_id, filename=file.filename, status="uploading")
+    contents[content_id] = content
+    logger.info("Content %s status changed to %s", content_id, content.status)
+
+    # Simulate processing to reach ready_for_distribution
+    content.status = "ready_for_distribution"
+    logger.info("Content %s status changed to %s", content_id, content.status)
+    return ContentResponse(**content.dict())
+
+
+@app.get("/content/{content_id}", response_model=ContentResponse)
+async def get_content(content_id: str) -> ContentResponse:
+    content = contents.get(content_id)
+    if not content:
+        raise HTTPException(status_code=404, detail="Content not found")
+    logger.info("Fetched content %s with status %s", content_id, content.status)
+    return ContentResponse(**content.dict())
+
+
+@app.post("/intent", response_model=IntentResponse)
+async def create_intent(request: CreateIntentRequest) -> IntentResponse:
+    logger.info(
+        "Received distribution intent request for content %s to platform %s",
+        request.content_id,
+        request.platform,
+    )
+
+    content = contents.get(request.content_id)
+    if not content:
+        raise HTTPException(status_code=404, detail="Content not found for intent")
+
+    intent_id = str(uuid.uuid4())
+    intent = DistributionIntent(
+        id=intent_id,
+        content_id=request.content_id,
+        platform=request.platform,
+        status="pending",
+    )
+    intents[intent_id] = intent
+    logger.info("Intent %s created with status %s", intent_id, intent.status)
+    return IntentResponse(**intent.dict())
+
+
+@app.get("/intent/{intent_id}", response_model=IntentResponse)
+async def get_intent(intent_id: str) -> IntentResponse:
+    intent = intents.get(intent_id)
+    if not intent:
+        raise HTTPException(status_code=404, detail="Intent not found")
+    logger.info(
+        "Fetched intent %s for content %s with status %s",
+        intent_id,
+        intent.content_id,
+        intent.status,
+    )
+    return IntentResponse(**intent.dict())
+
+
+@app.get("/health")
+async def health() -> dict:
+    return {"status": "ok"}
+
+
+if __name__ == "__main__":
+    import uvicorn
+
+    uvicorn.run(app, host="0.0.0.0", port=8000)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+fastapi==0.110.0
+uvicorn==0.29.0
+pydantic==1.10.14


### PR DESCRIPTION
## Summary
- add FastAPI backend with in-memory Content and DistributionIntent models
- provide upload and intent endpoints with status logging
- document running instructions and dependencies

## Testing
- python -m compileall main.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69450c00de9c832e9633625af729a95e)